### PR TITLE
Incrementally build converters and schema

### DIFF
--- a/cmd/gpq/convert.go
+++ b/cmd/gpq/convert.go
@@ -28,6 +28,8 @@ type ConvertCmd struct {
 	From   string `help:"Input file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
 	Output string `arg:"" name:"output" help:"Output file." type:"path"`
 	To     string `help:"Output file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
+	Min    int    `help:"Minimum number of features to consider when building a schema." default:"10"`
+	Max    int    `help:"Maximum number of features to consider when building a schema." default:"100"`
 }
 
 type FormatType string
@@ -57,7 +59,7 @@ func getFormatType(filename string) FormatType {
 	if strings.HasSuffix(filename, ".json") || strings.HasSuffix(filename, ".geojson") {
 		return GeoJSONType
 	}
-	if strings.HasSuffix(filename, ".parquet") || strings.HasSuffix(filename, ".geoparquet") {
+	if strings.HasSuffix(filename, ".pq") || strings.HasSuffix(filename, ".parquet") || strings.HasSuffix(filename, ".geoparquet") {
 		return GeoParquetType
 	}
 	return UnknownType
@@ -110,5 +112,6 @@ func (c *ConvertCmd) Run() error {
 		return geojson.FromParquet(file, output)
 	}
 
-	return geojson.ToParquet(input, output)
+	convertOptions := &geojson.ConvertOptions{MinFeatures: c.Min, MaxFeatures: c.Max}
+	return geojson.ToParquet(input, output, convertOptions)
 }

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -87,7 +87,7 @@ var toParquet = js.FuncOf(func(this js.Value, args []js.Value) any {
 
 	input := strings.NewReader(args[0].String())
 	output := &bytes.Buffer{}
-	convertErr := geojson.ToParquet(input, output)
+	convertErr := geojson.ToParquet(input, output, &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 250})
 
 	if convertErr != nil {
 		return returnFromError(convertErr)

--- a/internal/geojson/geojson_test.go
+++ b/internal/geojson/geojson_test.go
@@ -203,7 +203,7 @@ func TestToParquet(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	assert.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -240,7 +240,7 @@ func TestToParquetMismatchedTypes(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	assert.EqualError(t, toParquetErr, "mixed types for \"stringProperty\", expected string, but got float64")
 }
 
@@ -249,7 +249,7 @@ func TestToParquetRepeatedProps(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -274,7 +274,7 @@ func TestToParquetNullGeometry(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -299,7 +299,7 @@ func TestToParquetAllNullGeometry(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -331,7 +331,7 @@ func TestToParqueStringId(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -350,7 +350,7 @@ func TestToParqueNumberId(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -369,7 +369,7 @@ func TestToParqueBooleanId(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	assert.ErrorContains(t, toParquetErr, "expected id to be a string or number, got: true")
 }
 
@@ -378,7 +378,7 @@ func TestToParqueArrayId(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	assert.ErrorContains(t, toParquetErr, "expected id to be a string or number, got: [")
 }
 
@@ -387,7 +387,7 @@ func TestToParqueObjectId(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	assert.ErrorContains(t, toParquetErr, "expected id to be a string or number, got: {")
 }
 
@@ -396,7 +396,7 @@ func TestToParquetWithCRS(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -415,7 +415,7 @@ func TestToParquetExtraArray(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -446,7 +446,7 @@ func TestToParquetExtraObject(t *testing.T) {
 	require.NoError(t, openErr)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer)
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -479,7 +479,7 @@ func TestRoundTripRepeatedProps(t *testing.T) {
 	inputReader := bytes.NewReader(inputData)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer)
+	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -500,7 +500,7 @@ func TestRoundTripNestedProps(t *testing.T) {
 	inputReader := bytes.NewReader(inputData)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer)
+	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
@@ -521,7 +521,28 @@ func TestRoundTripNullGeometry(t *testing.T) {
 	inputReader := bytes.NewReader(inputData)
 
 	parquetBuffer := &bytes.Buffer{}
-	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer)
+	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer, nil)
+	require.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	jsonBuffer := &bytes.Buffer{}
+	convertErr := geojson.FromParquet(parquetFile, jsonBuffer)
+	require.NoError(t, convertErr)
+
+	assert.JSONEq(t, string(inputData), jsonBuffer.String())
+}
+
+func TestRoundTripSparseProperties(t *testing.T) {
+	inputPath := "testdata/sparse-properties.geojson"
+	inputData, readErr := os.ReadFile(inputPath)
+	require.NoError(t, readErr)
+	inputReader := bytes.NewReader(inputData)
+
+	parquetBuffer := &bytes.Buffer{}
+	toParquetErr := geojson.ToParquet(inputReader, parquetBuffer, nil)
 	require.NoError(t, toParquetErr)
 
 	parquetInput := bytes.NewReader(parquetBuffer.Bytes())

--- a/internal/geojson/testdata/sparse-properties.geojson
+++ b/internal/geojson/testdata/sparse-properties.geojson
@@ -1,0 +1,32 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "first": "one",
+        "second": null,
+        "third": null
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "first": null,
+        "second": "two",
+        "third": null
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": null,
+      "properties": {
+        "first": null,
+        "second": null,
+        "third": "three"
+      }
+    }
+  ]
+}

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,5 @@ gpq describe example.parquet
  * Non-geographic CRS information is not preserved when converting GeoParquet to GeoJSON.
  * Page and row group size is not configurable when writing GeoParquet.  This may change soon.
  * GeoParquet files are written using ZSTD compression.  This is not configurable but may change soon.
- * When reading GeoJSON, the schema is inferred from the first feature that has all non-null properties.  All other features must conform with this schema.
  * Reading GeoParquet files with multiple geometry columns is supported.  Reading GeoJSON files with multiple geometry properties is not supported.
  * Feature identifiers in GeoJSON are not written to GeoParquet columns.  This may change soon.


### PR DESCRIPTION
Previously, one feature at a time would be considered when building a Parquet schema from GeoJSON.  This meant that feature collections with "sparse" properties (lots of nulls or missing properties in some features) could not reliably be converted to GeoParquet.

With this change, the `convert` command takes `--min` and `--max` arguments to control the minimum and maximum number of GeoJSON features to consider when building a schema.  The schema is incrementally built using at least `min` features, and efforts to build a complete schema continue until `max` features.