### PR TITLE
Support WKT encoding and use column type when encoding is unknown

### DIFF
--- a/cmd/gpq/describe.go
+++ b/cmd/gpq/describe.go
@@ -45,14 +45,14 @@ func (c *DescribeCmd) Run() error {
 		return fileErr
 	}
 
-	geoMetadata, geoErr := geoparquet.GetGeoMetadata(file)
+	metadata, geoErr := geoparquet.GetMetadata(file)
 	if geoErr != nil {
 		return geoErr
 	}
 
 	info := &Info{
 		Schema:   buildSchema("", file.Schema()),
-		Metadata: geoMetadata,
+		Metadata: metadata,
 	}
 
 	encoder := json.NewEncoder(os.Stdout)
@@ -68,8 +68,8 @@ func (c *DescribeCmd) Run() error {
 }
 
 type Info struct {
-	Schema   *Schema                 `json:"schema"`
-	Metadata *geoparquet.GeoMetadata `json:"metadata"`
+	Schema   *Schema              `json:"schema"`
+	Metadata *geoparquet.Metadata `json:"metadata"`
 }
 
 type Schema struct {

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -67,11 +67,11 @@ var fromParquet = js.FuncOf(func(this js.Value, args []js.Value) any {
 		return returnFromError(convertErr)
 	}
 
-	geoMetadata, _ := input.Lookup("geo")
+	metadata, _ := input.Lookup("geo")
 
 	return returnFromValue(map[string]any{
 		"data":    output.String(),
-		"geo":     geoMetadata,
+		"geo":     metadata,
 		"schema":  input.Schema().String(),
 		"records": input.NumRows(),
 	})
@@ -98,14 +98,14 @@ var toParquet = js.FuncOf(func(this js.Value, args []js.Value) any {
 		return returnFromError(err)
 	}
 
-	geoMetadata, _ := file.Lookup("geo")
+	metadata, _ := file.Lookup("geo")
 
 	array := uint8ArrayConstructor.New(output.Len())
 	js.CopyBytesToJS(array, output.Bytes())
 
 	return returnFromValue(map[string]any{
 		"data":    array,
-		"geo":     geoMetadata,
+		"geo":     metadata,
 		"schema":  file.Schema().String(),
 		"records": file.NumRows(),
 	})

--- a/internal/geojson/metadata.go
+++ b/internal/geojson/metadata.go
@@ -20,8 +20,8 @@ import (
 
 const primaryColumn = "geometry"
 
-func GetDefaultMetadata() *geoparquet.GeoMetadata {
-	return &geoparquet.GeoMetadata{
+func GetDefaultMetadata() *geoparquet.Metadata {
+	return &geoparquet.Metadata{
 		Version:       geoparquet.Version,
 		PrimaryColumn: primaryColumn,
 		Columns: map[string]*geoparquet.GeometryColumn{

--- a/internal/geoparquet/geoparquet_test.go
+++ b/internal/geoparquet/geoparquet_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetGeoMetadataV040(t *testing.T) {
+func TestGetMetadataV040(t *testing.T) {
 	fixturePath := "../testdata/cases/example-v0.4.0.parquet"
 	info, statErr := os.Stat(fixturePath)
 	require.NoError(t, statErr)
@@ -36,21 +36,21 @@ func TestGetGeoMetadataV040(t *testing.T) {
 	file, fileErr := parquet.OpenFile(input, info.Size())
 	require.NoError(t, fileErr)
 
-	geoMetadata, geoErr := geoparquet.GetGeoMetadata(file)
+	metadata, geoErr := geoparquet.GetMetadata(file)
 	require.NoError(t, geoErr)
 
-	assert.Equal(t, "geometry", geoMetadata.PrimaryColumn)
-	assert.Equal(t, "0.4.0", geoMetadata.Version)
-	require.Len(t, geoMetadata.Columns, 1)
+	assert.Equal(t, "geometry", metadata.PrimaryColumn)
+	assert.Equal(t, "0.4.0", metadata.Version)
+	require.Len(t, metadata.Columns, 1)
 
-	col := geoMetadata.Columns[geoMetadata.PrimaryColumn]
+	col := metadata.Columns[metadata.PrimaryColumn]
 	assert.Equal(t, "WKB", col.Encoding)
 	assert.Equal(t, "planar", col.Edges)
 	assert.Equal(t, []float64{-180, -90, 180, 83.6451}, col.Bounds)
 	assert.Equal(t, []string{"Polygon", "MultiPolygon"}, col.GetGeometryTypes())
 }
 
-func TestGetGeoMetadataV100Beta1(t *testing.T) {
+func TestGetMetadataV100Beta1(t *testing.T) {
 	fixturePath := "../testdata/cases/example-v1.0.0-beta.1.parquet"
 	info, statErr := os.Stat(fixturePath)
 	require.NoError(t, statErr)
@@ -61,14 +61,14 @@ func TestGetGeoMetadataV100Beta1(t *testing.T) {
 	file, fileErr := parquet.OpenFile(input, info.Size())
 	require.NoError(t, fileErr)
 
-	geoMetadata, geoErr := geoparquet.GetGeoMetadata(file)
+	metadata, geoErr := geoparquet.GetMetadata(file)
 	require.NoError(t, geoErr)
 
-	assert.Equal(t, "geometry", geoMetadata.PrimaryColumn)
-	assert.Equal(t, "1.0.0-beta.1", geoMetadata.Version)
-	require.Len(t, geoMetadata.Columns, 1)
+	assert.Equal(t, "geometry", metadata.PrimaryColumn)
+	assert.Equal(t, "1.0.0-beta.1", metadata.Version)
+	require.Len(t, metadata.Columns, 1)
 
-	col := geoMetadata.Columns[geoMetadata.PrimaryColumn]
+	col := metadata.Columns[metadata.PrimaryColumn]
 	assert.Equal(t, "WKB", col.Encoding)
 	assert.Equal(t, "planar", col.Edges)
 	assert.Equal(t, []float64{-180, -90, 180, 83.6451}, col.Bounds)

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -80,7 +80,7 @@ func (v *Validator) Validate(ctx context.Context, resource string) error {
 		return fileErr
 	}
 
-	value, geoErr := geoparquet.GetGeoMetadataValue(file)
+	value, geoErr := geoparquet.GetMetadataValue(file)
 	if geoErr != nil {
 		return geoErr
 	}


### PR DESCRIPTION
This adds support for WKT encoded geometries.

Although the spec doesn't currently allow it, if `"encoding": "WKT"` metadata is included for a geometry column, the data will be read as WKT.

In addition, if no `encoding` metadata property is found for a geometry column, the encoding will be derived from the column type.  For columns annotated with the string logical type, WKT will be assumed.  For other byte arrays (with no string annotation), WKB will be assumed.