### PR TITLE
Add parquet compression option for converting geojson to parquet files

### DIFF
--- a/cmd/gpq/convert.go
+++ b/cmd/gpq/convert.go
@@ -24,12 +24,13 @@ import (
 )
 
 type ConvertCmd struct {
-	Input  string `arg:"" name:"input" help:"Input file." type:"existingfile"`
-	From   string `help:"Input file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
-	Output string `arg:"" name:"output" help:"Output file." type:"path"`
-	To     string `help:"Output file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
-	Min    int    `help:"Minimum number of features to consider when building a schema." default:"10"`
-	Max    int    `help:"Maximum number of features to consider when building a schema." default:"100"`
+	Input       string `arg:"" name:"input" help:"Input file." type:"existingfile"`
+	From        string `help:"Input file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
+	Output      string `arg:"" name:"output" help:"Output file." type:"path"`
+	To          string `help:"Output file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
+	Min         int    `help:"Minimum number of features to consider when building a schema." default:"10"`
+	Max         int    `help:"Maximum number of features to consider when building a schema." default:"100"`
+	Compression string `enum:"uncompressed,snappy,gzip,brotli,zstd,lz4raw" help:"Parquet compression to use" default:"zstd"`
 }
 
 type FormatType string
@@ -112,6 +113,6 @@ func (c *ConvertCmd) Run() error {
 		return geojson.FromParquet(file, output)
 	}
 
-	convertOptions := &geojson.ConvertOptions{MinFeatures: c.Min, MaxFeatures: c.Max}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: c.Min, MaxFeatures: c.Max, Compression: c.Compression}
 	return geojson.ToParquet(input, output, convertOptions)
 }

--- a/internal/geojson/geojson.go
+++ b/internal/geojson/geojson.go
@@ -28,6 +28,7 @@ import (
 	orbjson "github.com/paulmach/orb/geojson"
 	"github.com/planetlabs/gpq/internal/geoparquet"
 	"github.com/segmentio/parquet-go"
+	"github.com/segmentio/parquet-go/compress"
 )
 
 type FeatureWriter struct {
@@ -552,13 +553,34 @@ func (r *FeatureReader) readGeometryCollection() (*Feature, error) {
 type ConvertOptions struct {
 	MinFeatures int
 	MaxFeatures int
+	Compression string
 }
 
 var defaultOptions = &ConvertOptions{
 	MinFeatures: 1,
 	MaxFeatures: 50,
+	Compression: "zstd",
 }
 
+func getCodec(codec string) (compress.Codec, error) {
+	switch codec {
+	case "uncompressed":
+		return &parquet.Uncompressed, nil
+	case "snappy":
+		return &parquet.Snappy, nil
+	case "gzip":
+		return &parquet.Gzip, nil
+	case "brotli":
+		return &parquet.Brotli, nil
+	case "zstd":
+		return &parquet.Zstd, nil
+	case "lz4raw":
+		return &parquet.Lz4Raw, nil
+	default:
+		return nil, fmt.Errorf("invalid compression codec %s", codec)
+	}
+
+}
 func ToParquet(input io.Reader, output io.Writer, convertOptions *ConvertOptions) error {
 	reader := NewFeatureReader(input)
 
@@ -572,8 +594,12 @@ func ToParquet(input io.Reader, output io.Writer, convertOptions *ConvertOptions
 
 	schema := parquet.SchemaOf(reflect.New(converter.Type).Elem().Interface())
 
+	codec, codecErr := getCodec(convertOptions.Compression)
+	if codecErr != nil {
+		return codecErr
+	}
 	options := []parquet.WriterOption{
-		parquet.Compression(&parquet.Zstd),
+		parquet.Compression(codec),
 		schema,
 	}
 

--- a/internal/geojson/geojson_test.go
+++ b/internal/geojson/geojson_test.go
@@ -769,3 +769,112 @@ func TestWKBNoEncoding(t *testing.T) {
 
 	assert.JSONEq(t, expected, output.String())
 }
+
+func TestCodecUncompressed(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "uncompressed"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	assert.Equal(t, parquet.Uncompressed.CompressionCodec(), parquetFile.Metadata().RowGroups[0].Columns[0].MetaData.Codec)
+
+}
+
+func TestCodecSnappy(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "snappy"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	assert.Equal(t, parquet.Snappy.CompressionCodec(), parquetFile.Metadata().RowGroups[0].Columns[0].MetaData.Codec)
+
+}
+
+func TestCodecGzip(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "gzip"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	assert.Equal(t, parquet.Gzip.CompressionCodec(), parquetFile.Metadata().RowGroups[0].Columns[0].MetaData.Codec)
+
+}
+
+func TestCodecBrotli(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "brotli"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	assert.Equal(t, parquet.Brotli.CompressionCodec(), parquetFile.Metadata().RowGroups[0].Columns[0].MetaData.Codec)
+
+}
+func TestCodecZstd(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "zstd"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	assert.Equal(t, parquet.Zstd.CompressionCodec(), parquetFile.Metadata().RowGroups[0].Columns[0].MetaData.Codec)
+}
+
+func TestCodecLz4raw(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "lz4raw"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.NoError(t, toParquetErr)
+
+	parquetInput := bytes.NewReader(parquetBuffer.Bytes())
+	parquetFile, openErr := parquet.OpenFile(parquetInput, parquetInput.Size())
+	require.NoError(t, openErr)
+
+	assert.Equal(t, parquet.Lz4Raw.CompressionCodec(), parquetFile.Metadata().RowGroups[0].Columns[0].MetaData.Codec)
+}
+
+func TestCodecInvalid(t *testing.T) {
+	geojsonFile, openErr := os.Open("testdata/example.geojson")
+	require.NoError(t, openErr)
+
+	parquetBuffer := &bytes.Buffer{}
+	convertOptions := &geojson.ConvertOptions{MinFeatures: 10, MaxFeatures: 100, Compression: "invalid"}
+	toParquetErr := geojson.ToParquet(geojsonFile, parquetBuffer, convertOptions)
+	assert.EqualError(t, toParquetErr, "invalid compression codec invalid")
+}


### PR DESCRIPTION
Hi! 

I added an option to specify a compression option for converting geojson to parquet. 

I ended up not including LZO as it was not supported by [parquet-go library](https://pkg.go.dev/github.com/segmentio/parquet-go@v0.0.0-20230427215636-d483faba23a5/compress#section-directories)  and lz4 as it is considered [deprecated](https://pkg.go.dev/github.com/segmentio/parquet-go@v0.0.0-20230427215636-d483faba23a5/compress#section-directories) in parquet spec.

```sh
gbq convert --compression uncompressed sample.geojson sample-uncompressed.parquet
```

Ive also added some basic tests to ensure it actually works. 


Would appreciate feedback on this if i missed something as im not to familair with golang as a language! 