### PR TITLE
Use gzip by default

### DIFF
--- a/cmd/gpq/convert.go
+++ b/cmd/gpq/convert.go
@@ -30,7 +30,7 @@ type ConvertCmd struct {
 	To          string `help:"Output file format.  Possible values: ${enum}." enum:"auto, geojson, geoparquet" default:"auto"`
 	Min         int    `help:"Minimum number of features to consider when building a schema." default:"10"`
 	Max         int    `help:"Maximum number of features to consider when building a schema." default:"100"`
-	Compression string `help:"Parquet compression to use.  Possible values: ${enum}." enum:"uncompressed, snappy, gzip, brotli, zstd, lz4raw" default:"zstd"`
+	Compression string `help:"Parquet compression to use.  Possible values: ${enum}." enum:"uncompressed, snappy, gzip, brotli, zstd, lz4raw" default:"gzip"`
 }
 
 type FormatType string

--- a/internal/geojson/geojson.go
+++ b/internal/geojson/geojson.go
@@ -520,7 +520,7 @@ type ConvertOptions struct {
 var defaultOptions = &ConvertOptions{
 	MinFeatures: 1,
 	MaxFeatures: 50,
-	Compression: "zstd",
+	Compression: "gzip",
 }
 
 func getCodec(codec string) (compress.Codec, error) {


### PR DESCRIPTION
We have run into cases where support for reading ZSTD compressed Parquet is limited.  For tools like GDAL, this depends on the version of arrow-cpp that it was built with (and potentially which ZSTD related options).

This change updates the default compression to be `gzip` instead of `zstd`.  It is still possible to get ZSTD by passing `--compression zstd` to the `gpq convert` command.