### PR TITLE
Convert Parquet without metadata to GeoParquet

### DIFF
--- a/internal/validator/rules.go
+++ b/internal/validator/rules.go
@@ -505,7 +505,7 @@ func GeometryEncoding() Rule {
 			metadata := info.Metadata
 
 			for name, encoded := range geometries {
-				_, err := geoparquet.Geometry(encoded, name, metadata, schema)
+				_, _, err := geoparquet.Geometry(encoded, name, metadata, schema)
 				if err != nil {
 					return fatal("invalid geometry in column %q: %s", name, err)
 				}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -235,7 +235,7 @@ func (v *Validator) Report(ctx context.Context, file *parquet.File) (*Report, er
 
 		decodedGeometryMap := DecodedGeometryMap{}
 		for name, value := range encodedGeometryMap {
-			decoded, err := geoparquet.Geometry(value, name, metadata, schema)
+			decoded, _, err := geoparquet.Geometry(value, name, metadata, schema)
 			if err != nil {
 				return nil, fmt.Errorf("failed to decode geometry: %w", err)
 			}


### PR DESCRIPTION
This adds support for converting Parquet files without "geo" file metadata to GeoParquet files.
```bash
gpq convert non-geo.parquet geo.parquet
```

For this to work, the non-geo Parquet file must have a column named "geometry" with WKT or WKB encoded geometries.