### PR TITLE
Fix issue converting Parquet with WKT geometry

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,15 @@ gpq convert example.geojson example.parquet
 gpq convert example.parquet example.geojson
 ```
 
+The `convert` command can also be used to convert an input Parquet file without "geo" metadata to a valid GeoParquet file.
+
+```shell
+# read parquet and write geoparquet
+gpq convert non-geo.parquet valid-geo.parquet
+```
+
+When reading from a Parquet file and writing out GeoParquet, the input geometry values can be WKB or WKT encoded.  The output geometry values will always be WKB encoded.
+
 The `--compression` argument can be used to control the compression codec used when writing GeoParquet.  See `gpq convert --help` for the available options.
 
 


### PR DESCRIPTION
Previously, when converting an input Parquet file to a GeoParquet file, the same metadata struct would be used to read the input metadata and write the output metadata.  When the input geometry type is WKT, the output is converted to WKB.  During writing, the metadata was modified after writing the first geometry.  This meant that reading the second geometry failed since it was not WKB (but the modified metadata indicated that it was).

This change ensures that the input metadata is cloned before creating modified output metadata.

Fixes #34.