### PR TITLE
Additional information in describe output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/segmentio/encoding v0.3.6
 	github.com/segmentio/parquet-go v0.0.0-20230605165518-1fd7f3303070
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,7 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/geoparquet/geoparquet.go
+++ b/internal/geoparquet/geoparquet.go
@@ -71,11 +71,39 @@ func (m *Metadata) Clone() *Metadata {
 	return clone
 }
 
+type ProjId struct {
+	Authority string `json:"authority"`
+	Code      any    `json:"code"`
+}
+
+type Proj struct {
+	Name string  `json:"name"`
+	Id   *ProjId `json:"id"`
+}
+
+func (p *Proj) String() string {
+	id := ""
+	if p.Id != nil {
+		if code, ok := p.Id.Code.(string); ok {
+			id = p.Id.Authority + ":" + code
+		} else if code, ok := p.Id.Code.(float64); ok {
+			id = fmt.Sprintf("%s:%g", p.Id.Authority, code)
+		}
+	}
+	if p.Name != "" {
+		return p.Name
+	}
+	if id == "" {
+		return "Unknown"
+	}
+	return id
+}
+
 type GeometryColumn struct {
 	Encoding      string    `json:"encoding"`
 	GeometryType  any       `json:"geometry_type,omitempty"`
 	GeometryTypes any       `json:"geometry_types"`
-	CRS           any       `json:"crs,omitempty"`
+	CRS           *Proj     `json:"crs,omitempty"`
 	Edges         string    `json:"edges,omitempty"`
 	Orientation   string    `json:"orientation,omitempty"`
 	Bounds        []float64 `json:"bbox,omitempty"`

--- a/internal/geoparquet/geoparquet_test.go
+++ b/internal/geoparquet/geoparquet_test.go
@@ -79,6 +79,12 @@ func TestGetMetadataV100Beta1(t *testing.T) {
 	assert.Equal(t, "planar", col.Edges)
 	assert.Equal(t, []float64{-180, -90, 180, 83.6451}, col.Bounds)
 	assert.Equal(t, []string{"Polygon", "MultiPolygon"}, col.GetGeometryTypes())
+
+	require.NotNil(t, col.CRS)
+	require.NotNil(t, col.CRS.Id)
+	assert.Equal(t, "OGC", col.CRS.Id.Authority)
+	assert.Equal(t, "CRS84", col.CRS.Id.Code)
+	assert.Equal(t, "WGS 84 (CRS84)", col.CRS.Name)
 }
 
 func TestRowReaderV040(t *testing.T) {


### PR DESCRIPTION
This adds additional information to the describe output:
 * geometry column crs (name / id)
 * number of rows
 * geoparquet version

The edges, orientation, and crs per geometry column is summarized in a "detail" column in the text output.  Number of rows and version are shown in the table footer.  The primary geometry column name is shown in bold.
```shell
# gpq describe internal/testdata/cases/example-v1.0.0-beta.1.parquet
╭────────────┬──────────────┬────────────┬────────────┬──────────┬───────────────────────┬───────────────────────────┬──────────────────────────╮
│ COLUMN     │ TYPE         │ ANNOTATION │ REPETITION │ ENCODING │ GEOMETRY TYPES        │ BOUNDS                    │ DETAIL                   │
├────────────┼──────────────┼────────────┼────────────┼──────────┼───────────────────────┼───────────────────────────┼──────────────────────────┤
│ pop_est    │ int64        │            │ 0..1       │          │                       │                           │                          │
│ continent  │ binary       │ STRING     │ 0..1       │          │                       │                           │                          │
│ name       │ binary       │ STRING     │ 0..1       │          │                       │                           │                          │
│ iso_a3     │ binary       │ STRING     │ 0..1       │          │                       │                           │                          │
│ gdp_md_est │ double       │            │ 0..1       │          │                       │                           │                          │
│ geometry   │ binary       │            │ 0..1       │ WKB      │ Polygon, MultiPolygon │ [-180, -90, 180, 83.6451] │  edges │ planar          │
│            │              │            │            │          │                       │                           │  crs   │ WGS 84 (CRS84)  │
├────────────┼──────────────┼────────────┴────────────┴──────────┴───────────────────────┴───────────────────────────┴──────────────────────────┤
│ ROWS       │ 5            │                                                                                                                   │
│ VERSION    │ 1.0.0-BETA.1 │                                                                                                                   │
╰────────────┴──────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

