### PR TITLE
Report on compression in describe output

### DIFF
--- a/cmd/gpq/convert.go
+++ b/cmd/gpq/convert.go
@@ -114,11 +114,9 @@ func (c *ConvertCmd) Run() error {
 		return geojson.FromParquet(input, output)
 	}
 
-	var convertOptions *geoparquet.ConvertOptions
-	if c.InputPrimaryColumn != geoparquet.DefaultGeometryColumn {
-		convertOptions = &geoparquet.ConvertOptions{
-			InputPrimaryColumn: c.InputPrimaryColumn,
-		}
+	convertOptions := &geoparquet.ConvertOptions{
+		InputPrimaryColumn: c.InputPrimaryColumn,
+		Compression:        c.Compression,
 	}
 
 	return geoparquet.FromParquet(input, output, convertOptions)

--- a/internal/pqutil/parquet.go
+++ b/internal/pqutil/parquet.go
@@ -5,23 +5,10 @@ import (
 	"strings"
 
 	"github.com/apache/arrow/go/v14/parquet"
-	"github.com/apache/arrow/go/v14/parquet/file"
 	pqschema "github.com/apache/arrow/go/v14/parquet/schema"
 )
 
 var ParquetStringType = pqschema.StringLogicalType{}
-
-func GetParquetSchema(input parquet.ReaderAtSeeker) (*pqschema.Schema, error) {
-	fileReader, err := file.NewParquetReader(input)
-	if err != nil {
-		return nil, err
-	}
-	schema := fileReader.MetaData().Schema
-	if err := fileReader.Close(); err != nil {
-		return nil, err
-	}
-	return schema, nil
-}
 
 func LookupNode(schema *pqschema.Schema, name string) (pqschema.Node, bool) {
 	root := schema.Root()
@@ -131,7 +118,7 @@ func (w *parquetWriter) writeNode(node pqschema.Node, level int) {
 func (w *parquetWriter) writeGroupNode(node *pqschema.GroupNode, level int) {
 	repetition := node.RepetitionType().String()
 	name := node.Name()
-	annotation := logicalOrConvertedAnnotation(node)
+	annotation := LogicalOrConvertedAnnotation(node)
 
 	w.writeLine(fmt.Sprintf("%s group %s%s {", repetition, name, annotation), level)
 	for i := 0; i < node.NumFields(); i += 1 {
@@ -144,12 +131,12 @@ func (w *parquetWriter) writePrimitiveNode(node *pqschema.PrimitiveNode, level i
 	repetition := node.RepetitionType().String()
 	name := node.Name()
 	nodeType := physicalTypeString(node.PhysicalType())
-	annotation := logicalOrConvertedAnnotation(node)
+	annotation := LogicalOrConvertedAnnotation(node)
 
 	w.writeLine(fmt.Sprintf("%s %s %s%s;", repetition, nodeType, name, annotation), level)
 }
 
-func logicalOrConvertedAnnotation(node pqschema.Node) string {
+func LogicalOrConvertedAnnotation(node pqschema.Node) string {
 	logicalType := node.LogicalType()
 	convertedType := node.ConvertedType()
 

--- a/internal/pqutil/transform_test.go
+++ b/internal/pqutil/transform_test.go
@@ -144,7 +144,8 @@ func TestTransformColumn(t *testing.T) {
 		}
 	]`
 
-	transformSchema := func(inputSchema *schema.Schema) (*schema.Schema, error) {
+	transformSchema := func(fileReader *file.Reader) (*schema.Schema, error) {
+		inputSchema := fileReader.MetaData().Schema
 		inputRoot := inputSchema.Root()
 		numFields := inputRoot.NumFields()
 

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -83,7 +83,7 @@ func (s *Suite) copyWithMetadata(input parquet.ReaderAtSeeker, output io.Writer,
 	config := &pqutil.TransformConfig{
 		Reader: input,
 		Writer: output,
-		BeforeClose: func(fileWriter *file.Writer) error {
+		BeforeClose: func(fileReader *file.Reader, fileWriter *file.Writer) error {
 			return fileWriter.AppendKeyValueMetadata(geoparquet.MetadataKey, metadata)
 		},
 	}


### PR DESCRIPTION
This adds information about the column compression in the `describe` output.  For the `--format json` output, compression detail is provided on nested fields.  For the non-JSON output, only the top level fields are described.  And the compression is only reported based on columns in the first row group.

This also fixes an issue where Parquet to GeoParquet compression changes would only work when the input data was uncompressed.

Fixes #46.
Fixes #47.
