### PR TITLE
Optionally use stdin and stdout for validate, describe, and convert commands

### DIFF
--- a/cmd/gpq/command/command.go
+++ b/cmd/gpq/command/command.go
@@ -1,0 +1,16 @@
+package command
+
+import "io"
+
+var CLI struct {
+	Convert  ConvertCmd  `cmd:"" help:"Convert data from one format to another."`
+	Validate ValidateCmd `cmd:"" help:"Validate a GeoParquet file."`
+	Describe DescribeCmd `cmd:"" help:"Describe a GeoParquet file."`
+	Version  VersionCmd  `cmd:"" help:"Print the version of this program."`
+}
+
+type ReaderAtSeeker interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+}

--- a/cmd/gpq/command/command_test.go
+++ b/cmd/gpq/command/command_test.go
@@ -1,0 +1,65 @@
+package command_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type Suite struct {
+	suite.Suite
+	originalStdin  *os.File
+	mockStdin      *os.File
+	originalStdout *os.File
+	mockStdout     *os.File
+}
+
+func (s *Suite) SetupTest() {
+	stdin, err := os.CreateTemp("", "stdin")
+	s.Require().NoError(err)
+	s.originalStdin = os.Stdin
+	s.mockStdin = stdin
+	os.Stdin = stdin
+
+	stdout, err := os.CreateTemp("", "stdout")
+	s.Require().NoError(err)
+	s.originalStdout = os.Stdout
+	s.mockStdout = stdout
+	os.Stdout = stdout
+}
+
+func (s *Suite) writeStdin(data []byte) {
+	_, writeErr := s.mockStdin.Write(data)
+	s.Require().NoError(writeErr)
+	_, seekErr := s.mockStdin.Seek(0, 0)
+	s.Require().NoError(seekErr)
+}
+
+func (s *Suite) readStdout() []byte {
+	if _, seekErr := s.mockStdout.Seek(0, 0); seekErr != nil {
+		// assume the file is closed
+		stdout, err := os.Open(s.mockStdout.Name())
+		s.Require().NoError(err)
+		s.mockStdout = stdout
+	}
+	data, err := io.ReadAll(s.mockStdout)
+	s.Require().NoError(err)
+	return data
+}
+
+func (s *Suite) TearDownTest() {
+	os.Stdout = s.originalStdout
+	os.Stdin = s.originalStdin
+
+	_ = s.mockStdin.Close()
+	s.NoError(os.Remove(s.mockStdin.Name()))
+
+	_ = s.mockStdout.Close()
+	s.NoError(os.Remove(s.mockStdout.Name()))
+}
+
+func TestSuite(t *testing.T) {
+	suite.Run(t, &Suite{})
+}

--- a/cmd/gpq/command/convert_test.go
+++ b/cmd/gpq/command/convert_test.go
@@ -1,0 +1,122 @@
+package command_test
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/apache/arrow/go/v14/parquet/file"
+	"github.com/planetlabs/gpq/cmd/gpq/command"
+	"github.com/planetlabs/gpq/internal/geo"
+	"github.com/planetlabs/gpq/internal/test"
+)
+
+func (s *Suite) TestConvertGeoParquetToGeoJSONStdout() {
+	cmd := &command.ConvertCmd{
+		From:  "auto",
+		Input: "../../../internal/testdata/cases/example-v1.0.0.parquet",
+		To:    "geojson",
+	}
+
+	s.Require().NoError(cmd.Run())
+	data := s.readStdout()
+
+	collection := &geo.FeatureCollection{}
+	s.Require().NoError(json.Unmarshal(data, collection))
+	s.Len(collection.Features, 5)
+}
+
+func (s *Suite) TestConvertGeoJSONToGeoParquetStdout() {
+	cmd := &command.ConvertCmd{
+		From:  "auto",
+		Input: "../../../internal/geojson/testdata/example.geojson",
+		To:    "parquet",
+	}
+
+	s.Require().NoError(cmd.Run())
+	data := s.readStdout()
+
+	fileReader, err := file.NewParquetReader(bytes.NewReader(data))
+	s.Require().NoError(err)
+	defer fileReader.Close()
+
+	s.Equal(int64(5), fileReader.NumRows())
+}
+
+func (s *Suite) TestConvertGeoParquetToUnknownStdout() {
+	cmd := &command.ConvertCmd{
+		From:  "auto",
+		Input: "../../../internal/testdata/cases/example-v1.0.0.parquet",
+	}
+
+	s.ErrorContains(cmd.Run(), "when writing to stdout, the --to option must be provided")
+}
+
+func (s *Suite) TestConvertGeoJSONStdinToGeoParquetStdout() {
+	s.writeStdin([]byte(`{
+		"type": "FeatureCollection",
+		"features": [
+			{
+				"type": "Feature",
+				"properties": {
+					"name": "Null Island"
+				},
+				"geometry": {
+					"type": "Point",
+					"coordinates": [0, 0]
+				}
+			}
+		]
+	}`))
+
+	cmd := &command.ConvertCmd{
+		From: "geojson",
+		To:   "geoparquet",
+	}
+
+	s.Require().NoError(cmd.Run())
+	data := s.readStdout()
+
+	fileReader, err := file.NewParquetReader(bytes.NewReader(data))
+	s.Require().NoError(err)
+	defer fileReader.Close()
+
+	s.Equal(int64(1), fileReader.NumRows())
+}
+
+func (s *Suite) TestConvertGeoParquetStdinToGeoJSONStdout() {
+	s.writeStdin(test.GeoParquetFromJSON(s.T(), `{
+		"type": "FeatureCollection",
+		"features": [
+			{
+				"type": "Feature",
+				"properties": {
+					"name": "Null Island"
+				},
+				"geometry": {
+					"type": "Point",
+					"coordinates": [0, 0]
+				}
+			}
+		]
+	}`))
+
+	cmd := &command.ConvertCmd{
+		From: "geoparquet",
+		To:   "geojson",
+	}
+
+	s.Require().NoError(cmd.Run())
+	data := s.readStdout()
+
+	collection := &geo.FeatureCollection{}
+	s.Require().NoError(json.Unmarshal(data, collection))
+	s.Len(collection.Features, 1)
+}
+
+func (s *Suite) TestConvertUnknownStdinToGeoParquetStdout() {
+	cmd := &command.ConvertCmd{
+		To: "geoparquet",
+	}
+
+	s.ErrorContains(cmd.Run(), "when reading from stdin, the --from option must be provided")
+}

--- a/cmd/gpq/command/describe_test.go
+++ b/cmd/gpq/command/describe_test.go
@@ -1,0 +1,101 @@
+package command_test
+
+import (
+	"encoding/json"
+
+	"github.com/planetlabs/gpq/cmd/gpq/command"
+	"github.com/planetlabs/gpq/internal/test"
+)
+
+func (s *Suite) TestDescribe() {
+	cmd := &command.DescribeCmd{
+		Input:  "../../../internal/testdata/cases/example-v1.0.0.parquet",
+		Format: "json",
+	}
+
+	s.Require().NoError(cmd.Run())
+
+	output := s.readStdout()
+	info := &command.DescribeInfo{}
+	err := json.Unmarshal(output, info)
+	s.Require().NoError(err)
+
+	s.Equal(int64(5), info.NumRows)
+	s.Require().Len(info.Schema.Fields, 6)
+
+	s.Equal("geometry", info.Schema.Fields[0].Name)
+	s.Equal("binary", info.Schema.Fields[0].Type)
+	s.Equal("gzip", info.Schema.Fields[0].Compression)
+	s.True(info.Schema.Fields[0].Optional)
+
+	s.Equal("pop_est", info.Schema.Fields[1].Name)
+	s.Equal("double", info.Schema.Fields[1].Type)
+	s.Equal("gzip", info.Schema.Fields[1].Compression)
+	s.True(info.Schema.Fields[1].Optional)
+
+	s.Equal("continent", info.Schema.Fields[2].Name)
+	s.Equal("binary", info.Schema.Fields[2].Type)
+	s.Equal("string", info.Schema.Fields[2].Annotation)
+	s.Equal("gzip", info.Schema.Fields[2].Compression)
+	s.True(info.Schema.Fields[2].Optional)
+
+	s.Equal("gdp_md_est", info.Schema.Fields[3].Name)
+	s.Equal("double", info.Schema.Fields[3].Type)
+	s.Equal("gzip", info.Schema.Fields[3].Compression)
+	s.True(info.Schema.Fields[3].Optional)
+
+	s.Equal("iso_a3", info.Schema.Fields[4].Name)
+	s.Equal("binary", info.Schema.Fields[4].Type)
+	s.Equal("string", info.Schema.Fields[4].Annotation)
+	s.Equal("gzip", info.Schema.Fields[4].Compression)
+	s.True(info.Schema.Fields[4].Optional)
+
+	s.Equal("name", info.Schema.Fields[5].Name)
+	s.Equal("binary", info.Schema.Fields[5].Type)
+	s.Equal("string", info.Schema.Fields[5].Annotation)
+	s.Equal("gzip", info.Schema.Fields[5].Compression)
+	s.True(info.Schema.Fields[5].Optional)
+}
+
+func (s *Suite) TestDescribeFromStdin() {
+	s.writeStdin(test.GeoParquetFromJSON(s.T(), `{
+		"type": "FeatureCollection",
+		"features": [
+			{
+				"type": "Feature",
+				"properties": {
+					"name": "Null Island"
+				},
+				"geometry": {
+					"type": "Point",
+					"coordinates": [0, 0]
+				}
+			}
+		]
+	}`))
+
+	cmd := &command.DescribeCmd{
+		Format: "json",
+	}
+
+	s.Require().NoError(cmd.Run())
+
+	output := s.readStdout()
+	info := &command.DescribeInfo{}
+	err := json.Unmarshal(output, info)
+	s.Require().NoError(err)
+
+	s.Equal(int64(1), info.NumRows)
+	s.Require().Len(info.Schema.Fields, 2)
+
+	s.Equal("geometry", info.Schema.Fields[0].Name)
+	s.Equal("binary", info.Schema.Fields[0].Type)
+	s.Equal("zstd", info.Schema.Fields[0].Compression)
+	s.True(info.Schema.Fields[0].Optional)
+
+	s.Equal("name", info.Schema.Fields[1].Name)
+	s.Equal("binary", info.Schema.Fields[1].Type)
+	s.Equal("string", info.Schema.Fields[1].Annotation)
+	s.Equal("zstd", info.Schema.Fields[1].Compression)
+	s.True(info.Schema.Fields[1].Optional)
+}

--- a/cmd/gpq/command/validate.go
+++ b/cmd/gpq/command/validate.go
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package command
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -27,15 +29,36 @@ import (
 )
 
 type ValidateCmd struct {
-	Input        string `arg:"" name:"input" help:"Input file." type:"existingfile"`
+	Input        string `arg:"" optional:"" name:"input" help:"Path to a GeoParquet file.  If not provided, input is read from stdin." type:"existingfile"`
 	MetadataOnly bool   `help:"Only run rules that apply to file metadata and schema (no data will be scanned)."`
 	Unpretty     bool   `help:"No colors in text output, no newlines and indentation in JSON output."`
 	Format       string `help:"Report format.  Possible values: ${enum}." enum:"text, json" default:"text"`
 }
 
 func (c *ValidateCmd) Run(ctx *kong.Context) error {
+	inputName := c.Input
+	var input ReaderAtSeeker
+	if c.Input == "" {
+		if !hasStdin() {
+			return fmt.Errorf("input argument must be provided if there is no stdin data")
+		}
+		data, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("trouble reading from stdin: %w", err)
+		}
+		input = bytes.NewReader(data)
+		inputName = "<stdin>"
+	} else {
+		i, readErr := os.Open(c.Input)
+		if readErr != nil {
+			return fmt.Errorf("failed to read from %q: %w", c.Input, readErr)
+		}
+		defer i.Close()
+		input = i
+	}
+
 	v := validator.New(c.MetadataOnly)
-	report, err := v.Validate(context.Background(), c.Input)
+	report, err := v.Validate(context.Background(), input, inputName)
 	if err != nil {
 		return err
 	}

--- a/cmd/gpq/command/version.go
+++ b/cmd/gpq/command/version.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package command
 
 import "fmt"
 

--- a/cmd/gpq/main.go
+++ b/cmd/gpq/main.go
@@ -16,17 +16,11 @@ package main
 
 import (
 	"github.com/alecthomas/kong"
+	"github.com/planetlabs/gpq/cmd/gpq/command"
 )
 
-var CLI struct {
-	Convert  ConvertCmd  `cmd:"" help:"Convert data from one format to another."`
-	Validate ValidateCmd `cmd:"" help:"Validate a GeoParquet file."`
-	Describe DescribeCmd `cmd:"" help:"Describe a GeoParquet file."`
-	Version  VersionCmd  `cmd:"" help:"Print the version of this program."`
-}
-
 func main() {
-	ctx := kong.Parse(&CLI)
+	ctx := kong.Parse(&command.CLI)
 	err := ctx.Run(ctx)
 	ctx.FatalIfErrorf(err)
 }

--- a/internal/geoparquet/geoparquet.go
+++ b/internal/geoparquet/geoparquet.go
@@ -57,7 +57,7 @@ func FromParquet(input parquet.ReaderAtSeeker, output io.Writer, convertOptions 
 		compression = &c
 	}
 
-	datasetInfo := geo.NewDatasetInfo(true)
+	datasetInfo := geo.NewDatasetStats(true)
 	transformSchema := func(fileReader *file.Reader) (*schema.Schema, error) {
 		inputSchema := fileReader.MetaData().Schema
 		metadata := getMetadata(fileReader, convertOptions)
@@ -109,7 +109,7 @@ func FromParquet(input parquet.ReaderAtSeeker, output io.Writer, convertOptions 
 		builder := array.NewBinaryBuilder(memory.DefaultAllocator, arrow.BinaryTypes.Binary)
 		defer builder.Release()
 
-		collectionInfo := geo.NewCollectionInfo(false)
+		collectionInfo := geo.NewGeometryStats(false)
 		for i, arr := range chunks {
 			stringArray, ok := arr.(*array.String)
 			if !ok {

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -20,9 +20,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/apache/arrow/go/v14/arrow/array"
+	"github.com/apache/arrow/go/v14/parquet"
 	"github.com/apache/arrow/go/v14/parquet/file"
 	"github.com/paulmach/orb"
 	"github.com/planetlabs/gpq/internal/geo"
@@ -93,16 +93,10 @@ type Check struct {
 }
 
 // Validate opens and validates a GeoParquet file.
-func (v *Validator) Validate(ctx context.Context, resource string) (*Report, error) {
-	input, inputErr := os.Open(resource)
-	if inputErr != nil {
-		return nil, fmt.Errorf("failed to read from %q: %w", resource, inputErr)
-	}
-	defer input.Close()
-
+func (v *Validator) Validate(ctx context.Context, input parquet.ReaderAtSeeker, name string) (*Report, error) {
 	reader, readerErr := file.NewParquetReader(input)
 	if readerErr != nil {
-		return nil, fmt.Errorf("failed to create parquet reader from %q: %w", resource, readerErr)
+		return nil, fmt.Errorf("failed to create parquet reader from %q: %w", name, readerErr)
 	}
 	defer reader.Close()
 

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -142,13 +142,15 @@ func (s *Suite) TestValidCases() {
 
 	for _, c := range cases {
 		s.Run(c, func() {
-			resourcePath := path.Join("../testdata/cases", c)
+			filePath := path.Join("../testdata/cases", c)
+			data, err := os.ReadFile(filePath)
+			s.Require().NoError(err)
 
-			allReport, allErr := validatorAll.Validate(ctx, resourcePath)
+			allReport, allErr := validatorAll.Validate(ctx, bytes.NewReader(data), filePath)
 			s.Require().NoError(allErr)
 			s.assertExpectedReport("all-pass", allReport)
 
-			metaReport, metaErr := validatorMeta.Validate(ctx, resourcePath)
+			metaReport, metaErr := validatorMeta.Validate(ctx, bytes.NewReader(data), filePath)
 			s.Require().NoError(metaErr)
 			s.assertExpectedReport("all-pass-meta", metaReport)
 		})


### PR DESCRIPTION
This makes it so the commands optionally read from stdin and write to stdout.

Examples:
```
# validate geoparquet from stdin
cat example.parquet | gpq validate

# describe geoparquet from stdin
cat example.parquet | gpq describe

# convert geoparquet from stdin to geojson stdout
cat example.parquet | gpq convert --from geoparquet --to geojson

# convert geojson to geoparquet stdout
gpq convert example.geojson --to geoparquet
```

Fixes #78.