### PR TITLE
Suggest running validate if metadata parsing fails in describe

### DIFF
--- a/cmd/gpq/command/describe.go
+++ b/cmd/gpq/command/describe.go
@@ -97,7 +97,11 @@ func (c *DescribeCmd) Run() error {
 	metadata, geoErr := geoparquet.GetMetadata(fileMetadata.KeyValueMetadata())
 	if geoErr != nil {
 		if !errors.Is(geoErr, geoparquet.ErrNoMetadata) {
-			message := fmt.Sprintf("Metadata parsing failed, try running describe with the --metadata-only flag.  Error message: %s", geoErr.Error())
+			message := fmt.Sprintf(
+				"Metadata parsing failed."+
+					" Run describe with the --metadata-only flag to see the geo metadata value."+
+					" Run validate for more detail on validation issues."+
+					" (Error message: %s)", geoErr.Error())
 			info.Issues = append(info.Issues, message)
 		}
 	} else {

--- a/cmd/gpq/command/describe.go
+++ b/cmd/gpq/command/describe.go
@@ -96,12 +96,21 @@ func (c *DescribeCmd) Run() error {
 
 	metadata, geoErr := geoparquet.GetMetadata(fileMetadata.KeyValueMetadata())
 	if geoErr != nil {
-		if !errors.Is(geoErr, geoparquet.ErrNoMetadata) {
+		if errors.Is(geoErr, geoparquet.ErrNoMetadata) {
 			message := fmt.Sprintf(
-				"Metadata parsing failed."+
-					" Run describe with the --metadata-only flag to see the geo metadata value."+
-					" Run validate for more detail on validation issues."+
-					" (Error message: %s)", geoErr.Error())
+				"Not a valid GeoParquet file (missing the %q metadata key)."+
+					" Run convert to try to convert it to GeoParquet.",
+				geoparquet.MetadataKey,
+			)
+			info.Issues = append(info.Issues, message)
+		} else {
+			message := fmt.Sprintf(
+				"Not a valid GeoParquet file (invalid %q metadata)."+
+					" Run describe with the --metadata-only flag to see the %q metadata value."+
+					" Run validate for more detail on validation issues.",
+				geoparquet.MetadataKey,
+				geoparquet.MetadataKey,
+			)
 			info.Issues = append(info.Issues, message)
 		}
 	} else {
@@ -131,12 +140,16 @@ func (c *DescribeCmd) formatText(info *DescribeInfo) error {
 	if metadata != nil {
 		header = append(header, ColEncoding, ColGeometryTypes, ColBounds, ColDetail)
 		columnConfigs = append(columnConfigs, table.ColumnConfig{
+			Name:             ColEncoding,
+			WidthMax:         40,
+			WidthMaxEnforcer: text.WrapSoft,
+		}, table.ColumnConfig{
 			Name:             ColGeometryTypes,
-			WidthMax:         50,
+			WidthMax:         40,
 			WidthMaxEnforcer: text.WrapSoft,
 		}, table.ColumnConfig{
 			Name:             ColBounds,
-			WidthMax:         50,
+			WidthMax:         40,
 			WidthMaxEnforcer: text.WrapSoft,
 		})
 	}

--- a/internal/pqutil/transform_test.go
+++ b/internal/pqutil/transform_test.go
@@ -85,7 +85,7 @@ func TestTransformByColumn(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("%s (case %d)", c.name, i), func(t *testing.T) {
-			input := test.ParquetFromJSON(t, c.data, nil)
+			input := bytes.NewReader(test.ParquetFromJSON(t, c.data, nil))
 			output := &bytes.Buffer{}
 			config := c.config
 			if config == nil {
@@ -174,7 +174,7 @@ func TestTransformByRowGroupLength(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("%s (case %d)", c.name, i), func(t *testing.T) {
 			writerProperties := parquet.NewWriterProperties(parquet.WithMaxRowGroupLength(int64(c.inputRowGroupLength)))
-			input := test.ParquetFromJSON(t, string(inputData), writerProperties)
+			input := bytes.NewReader(test.ParquetFromJSON(t, string(inputData), writerProperties))
 			output := &bytes.Buffer{}
 			config := c.config
 			if config == nil {
@@ -293,7 +293,7 @@ func TestTransformColumn(t *testing.T) {
 		return arrow.NewChunked(builder.Type(), transformed), nil
 	}
 
-	input := test.ParquetFromJSON(t, data, nil)
+	input := bytes.NewReader(test.ParquetFromJSON(t, data, nil))
 	output := &bytes.Buffer{}
 	config := &pqutil.TransformConfig{
 		Reader:          input,

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ParquetFromJSON(t *testing.T, data string, writerProperties *parquet.WriterProperties) parquet.ReaderAtSeeker {
+func ParquetFromJSON(t *testing.T, data string, writerProperties *parquet.WriterProperties) []byte {
 	if writerProperties == nil {
 		writerProperties = parquet.NewWriterProperties()
 	}
@@ -50,7 +50,7 @@ func ParquetFromJSON(t *testing.T, data string, writerProperties *parquet.Writer
 	require.NoError(t, writer.WriteBuffered(rec))
 	require.NoError(t, writer.Close())
 
-	return bytes.NewReader(output.Bytes())
+	return output.Bytes()
 }
 
 func ParquetToJSON(t *testing.T, input parquet.ReaderAtSeeker) string {


### PR DESCRIPTION
This adds output to the `describe` command that suggests running `validate` if the geo metadata is invalid.

Example output:
```shell
# gpq describe invalid.geoparquet
╭──────────┬────────┬────────────┬────────────┬─────────────╮
│ COLUMN   │ TYPE   │ ANNOTATION │ REPETITION │ COMPRESSION │
├──────────┼────────┼────────────┼────────────┼─────────────┤
│ geoid    │ binary │ string     │ 0..1       │ snappy      │
│ geometry │ binary │            │ 0..1       │ snappy      │
├──────────┼────────┴────────────┴────────────┴─────────────┤
│ Rows     │ 3233                                           │
╰──────────┴────────────────────────────────────────────────╯
 ⚠️  Not a valid GeoParquet file (invalid "geo" metadata). Run describe with the --metadata-only flag 
to see the "geo" metadata value. Run validate for more detail on validation issues.
```

In addition, this change adds a suggestion in the `describe` output to run `validate` if the file is missing geo metadata altogether.

Example output:
```shell
# gpq describe not-geo.parquet
╭───────────────────┬────────┬────────────┬────────────┬──────────────╮
│ COLUMN            │ TYPE   │ ANNOTATION │ REPETITION │ COMPRESSION  │
├───────────────────┼────────┼────────────┼────────────┼──────────────┤
│ registration_dttm │ int96  │            │ 0..1       │ uncompressed │
│ id                │ int32  │            │ 0..1       │ uncompressed │
│ first_name        │ binary │ string     │ 0..1       │ uncompressed │
│ last_name         │ binary │ string     │ 0..1       │ uncompressed │
│ email             │ binary │ string     │ 0..1       │ uncompressed │
│ gender            │ binary │ string     │ 0..1       │ uncompressed │
│ ip_address        │ binary │ string     │ 0..1       │ uncompressed │
│ cc                │ binary │ string     │ 0..1       │ uncompressed │
│ country           │ binary │ string     │ 0..1       │ uncompressed │
│ birthdate         │ binary │ string     │ 0..1       │ uncompressed │
│ salary            │ double │            │ 0..1       │ uncompressed │
│ title             │ binary │ string     │ 0..1       │ uncompressed │
│ comments          │ binary │ string     │ 0..1       │ uncompressed │
├───────────────────┼────────┴────────────┴────────────┴──────────────┤
│ Rows              │ 1000                                            │
╰───────────────────┴─────────────────────────────────────────────────╯
 ⚠️  Not a valid GeoParquet file (missing the "geo" metadata key). Run convert to try to convert it 
to GeoParquet.
```

Fixes #87.