### PR TITLE
Accept URLs for describe, validate, and convert input

### DIFF
--- a/cmd/gpq/command/command_test.go
+++ b/cmd/gpq/command/command_test.go
@@ -2,6 +2,8 @@ package command_test
 
 import (
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -14,6 +16,7 @@ type Suite struct {
 	mockStdin      *os.File
 	originalStdout *os.File
 	mockStdout     *os.File
+	server         *httptest.Server
 }
 
 func (s *Suite) SetupTest() {
@@ -28,6 +31,9 @@ func (s *Suite) SetupTest() {
 	s.originalStdout = os.Stdout
 	s.mockStdout = stdout
 	os.Stdout = stdout
+
+	handler := http.FileServer(http.Dir("../../../internal"))
+	s.server = httptest.NewServer(handler)
 }
 
 func (s *Suite) writeStdin(data []byte) {
@@ -58,6 +64,8 @@ func (s *Suite) TearDownTest() {
 
 	_ = s.mockStdout.Close()
 	s.NoError(os.Remove(s.mockStdout.Name()))
+
+	s.server.Close()
 }
 
 func TestSuite(t *testing.T) {

--- a/cmd/gpq/command/convert_test.go
+++ b/cmd/gpq/command/convert_test.go
@@ -120,3 +120,17 @@ func (s *Suite) TestConvertUnknownStdinToGeoParquetStdout() {
 
 	s.ErrorContains(cmd.Run(), "when reading from stdin, the --from option must be provided")
 }
+
+func (s *Suite) TestConvertGeoParquetUrlToGeoJSONStdout() {
+	cmd := &command.ConvertCmd{
+		Input: s.server.URL + "/testdata/cases/example-v1.0.0.parquet",
+		To:    "geojson",
+	}
+
+	s.Require().NoError(cmd.Run())
+	data := s.readStdout()
+
+	collection := &geo.FeatureCollection{}
+	s.Require().NoError(json.Unmarshal(data, collection))
+	s.Len(collection.Features, 5)
+}

--- a/cmd/gpq/command/describe_test.go
+++ b/cmd/gpq/command/describe_test.go
@@ -172,3 +172,28 @@ func (s *Suite) TestDescribeMissingMetadata() {
 	s.Require().Len(info.Issues, 1)
 	s.Contains(info.Issues[0], "Not a valid GeoParquet file (missing the \"geo\" metadata key).")
 }
+
+func (s *Suite) TestDescribeFromUrl() {
+	cmd := &command.DescribeCmd{
+		Format: "json",
+		Input:  s.server.URL + "/testdata/cases/example-v1.0.0.parquet",
+	}
+
+	s.Require().NoError(cmd.Run())
+
+	output := s.readStdout()
+	info := &command.DescribeInfo{}
+	err := json.Unmarshal(output, info)
+	s.Require().NoError(err)
+
+	s.Equal(int64(5), info.NumRows)
+	s.Equal(int64(1), info.NumRowGroups)
+	s.Require().Len(info.Schema.Fields, 6)
+
+	s.Equal("geometry", info.Schema.Fields[0].Name)
+	s.Equal("binary", info.Schema.Fields[0].Type)
+	s.Equal("gzip", info.Schema.Fields[0].Compression)
+	s.True(info.Schema.Fields[0].Optional)
+
+	s.Len(info.Issues, 0)
+}

--- a/internal/storage/http.go
+++ b/internal/storage/http.go
@@ -1,0 +1,185 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+const (
+	initialHttpRequestSize = 512
+	minHttpRequestSize     = 1024
+)
+
+type HttpReader struct {
+	url          string
+	offset       int64
+	size         int64
+	client       *http.Client
+	buffer       ReaderAtSeeker
+	bufferOffset int64
+	bufferSize   int64
+	validator    string
+}
+
+var _ ReaderAtSeeker = (*HttpReader)(nil)
+
+func NewHttpReader(url string) (*HttpReader, error) {
+	reader := &HttpReader{
+		url:    url,
+		client: &http.Client{},
+	}
+	if err := reader.init(); err != nil {
+		return nil, err
+	}
+	return reader, nil
+}
+
+func (r *HttpReader) init() error {
+	req, err := http.NewRequest(http.MethodGet, r.url, nil)
+	if err != nil {
+		return err
+	}
+
+	// make an initial range request to determine size
+	req.Header.Add("Range", fmt.Sprintf("bytes=0-%d", initialHttpRequestSize-1))
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if !success(resp) {
+		return fmt.Errorf("unexpected response from %s: %d", r.url, resp.StatusCode)
+	}
+
+	data, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return fmt.Errorf("failed to read response from %s: %w", r.url, readErr)
+	}
+
+	r.buffer = bytes.NewReader(data)
+	r.bufferSize = int64(len(data))
+
+	str := resp.Header.Get("Content-Range")
+	if strings.Contains(str, "/") {
+		size, err := strconv.ParseInt(strings.Split(str, "/")[1], 10, 64)
+		if err != nil {
+			return fmt.Errorf("invalid content-range header from %s: %w", r.url, err)
+		}
+		r.size = size
+		r.validator = validatorFromResponse(resp)
+	} else {
+		r.size = int64(len(data))
+	}
+	return nil
+}
+
+func success(response *http.Response) bool {
+	return response.StatusCode >= http.StatusOK && response.StatusCode < http.StatusMultipleChoices
+}
+
+func validatorFromResponse(resp *http.Response) string {
+	etag := resp.Header.Get("ETag")
+	if etag != "" && etag[0] == '"' {
+		return etag
+	}
+
+	return resp.Header.Get("Last-Modified")
+}
+
+func (r *HttpReader) ReadAt(data []byte, offset int64) (int, error) {
+	_, err := r.Seek(offset, io.SeekStart)
+	if err != nil {
+		return 0, err
+	}
+
+	total := 0
+	for {
+		if total >= len(data) {
+			break
+		}
+		n, err := r.Read(data[total:])
+		if err != nil {
+			return total + n, err
+		}
+		total = total + n
+	}
+	return total, nil
+}
+
+func (r *HttpReader) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekCurrent:
+		offset = r.offset + offset
+	case io.SeekEnd:
+		offset = r.size + offset
+	}
+
+	if offset < 0 {
+		return 0, fmt.Errorf("attempt to seek to a negative offset: %d", offset)
+	}
+	r.offset = offset
+	return offset, nil
+}
+
+func (r *HttpReader) Read(data []byte) (n int, err error) {
+	if r.offset > r.size {
+		return 0, io.EOF
+	}
+	if r.buffer == nil || r.offset < r.bufferOffset || r.offset > r.bufferOffset+r.bufferSize {
+		if err := r.request(int64(len(data))); err != nil {
+			return 0, err
+		}
+	}
+	read, err := r.buffer.ReadAt(data, r.offset-r.bufferOffset)
+	r.offset = r.offset + int64(read)
+	if err == io.EOF && r.offset < r.size {
+		r.buffer = nil
+		return read, nil
+	}
+	return read, err
+}
+
+func (r *HttpReader) request(size int64) error {
+	req, err := http.NewRequest(http.MethodGet, r.url, nil)
+	if err != nil {
+		return err
+	}
+	requestSize := size
+	if requestSize < minHttpRequestSize {
+		requestSize = minHttpRequestSize
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", r.offset, r.offset+requestSize))
+	if r.validator != "" {
+		req.Header.Set("If-Range", r.validator)
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if !success(resp) {
+		return fmt.Errorf("unexpected response from %s: %d", r.url, resp.StatusCode)
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	r.buffer = bytes.NewReader(data)
+	r.bufferOffset = r.offset
+	r.bufferSize = int64(len(data))
+	return nil
+}
+
+func (r *HttpReader) Close() {
+	if r.buffer != nil {
+		r.buffer = nil
+	}
+	r.client.CloseIdleConnections()
+}

--- a/internal/storage/http_test.go
+++ b/internal/storage/http_test.go
@@ -1,0 +1,200 @@
+package storage_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/planetlabs/gpq/internal/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func randBytes(t *testing.T, size int) []byte {
+	data := make([]byte, size)
+	n, err := rand.Read(data)
+	require.NoError(t, err)
+	require.Equal(t, n, size)
+	return data
+}
+
+func contentUrl(t *testing.T, content []byte) string {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		http.ServeContent(w, r, "content.txt", time.Time{}, bytes.NewReader([]byte(content)))
+	}))
+	return server.URL
+}
+
+func TestHttpReaderReadAll(t *testing.T) {
+	content := randBytes(t, 1000)
+	url := contentUrl(t, content)
+
+	reader, err := storage.NewHttpReader(url)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	data, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	assert.Equal(t, len(content), len(data))
+	assert.Equal(t, content, data)
+}
+
+func TestHttpReaderReadAt(t *testing.T) {
+	content := randBytes(t, 1000)
+	url := contentUrl(t, content)
+
+	httpReader, err := storage.NewHttpReader(url)
+	require.NoError(t, err)
+	defer httpReader.Close()
+
+	byteReader := bytes.NewReader(content)
+
+	cases := []struct {
+		name   string
+		offset int
+		size   int
+		err    string
+	}{
+		{
+			name:   "first read",
+			offset: 700,
+			size:   50,
+		},
+		{
+			name:   "second read",
+			offset: 10,
+			size:   10,
+		},
+		{
+			name:   "offset after end",
+			offset: len(content) + 10,
+			size:   10,
+			err:    io.EOF.Error(),
+		},
+		{
+			name:   "offset near end",
+			offset: len(content) - 10,
+			size:   20,
+			err:    io.EOF.Error(),
+		},
+		{
+			name:   "offset before start",
+			offset: -1,
+			size:   10,
+			err:    "attempt to seek to a negative offset: -1",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%s (case %d)", c.name, i), func(t *testing.T) {
+			data := make([]byte, c.size)
+			read, err := httpReader.ReadAt(data, int64(c.offset))
+			if c.err == "" {
+				require.NoError(t, err)
+			}
+			if err != nil {
+				assert.ErrorContains(t, err, c.err)
+			}
+			expected := make([]byte, c.size)
+			expectedRead, _ := byteReader.ReadAt(expected, int64(c.offset))
+			require.Equal(t, expectedRead, read)
+			assert.Equal(t, expected[:read], data[:read])
+		})
+	}
+}
+
+func TestHttpReaderSeek(t *testing.T) {
+	content := randBytes(t, 1000)
+	url := contentUrl(t, content)
+
+	httpReader, err := storage.NewHttpReader(url)
+	require.NoError(t, err)
+	defer httpReader.Close()
+
+	byteReader := bytes.NewReader(content)
+
+	cases := []struct {
+		name   string
+		offset int
+		whence int
+		err    string
+	}{
+		{
+			name:   "seek start",
+			offset: 700,
+			whence: io.SeekStart,
+		},
+		{
+			name:   "seek current",
+			offset: 10,
+			whence: io.SeekCurrent,
+		},
+		{
+			name:   "seek end",
+			offset: -10,
+			whence: io.SeekEnd,
+		},
+		{
+			name:   "offset beyond end",
+			offset: 10,
+			whence: io.SeekEnd,
+		},
+		{
+			name:   "offset before start",
+			offset: -1,
+			whence: io.SeekStart,
+			err:    "attempt to seek to a negative offset: -1",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("%s (case %d)", c.name, i), func(t *testing.T) {
+			data := make([]byte, 10)
+			offset, seekErr := httpReader.Seek(int64(c.offset), c.whence)
+			if c.err == "" {
+				require.NoError(t, seekErr)
+				return
+			}
+			if seekErr != nil {
+				require.ErrorContains(t, seekErr, c.err)
+				return
+			}
+
+			total := 0
+			for {
+				read, readErr := httpReader.Read(data[total:])
+				total += read
+				if readErr == io.EOF {
+					break
+				}
+				require.NoError(t, readErr)
+			}
+
+			expectedOffset, _ := byteReader.Seek(int64(c.offset), c.whence)
+			assert.Equal(t, expectedOffset, offset)
+
+			expected := make([]byte, len(data))
+			expectedTotal := 0
+			for {
+				read, err := byteReader.Read(expected[expectedTotal:])
+				expectedTotal += read
+				if err == io.EOF {
+					break
+				}
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, expectedTotal, total)
+			assert.Equal(t, expected[:total], data[:total])
+		})
+	}
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -1,0 +1,9 @@
+package storage
+
+import "io"
+
+type ReaderAtSeeker interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+}


### PR DESCRIPTION
This adds support for using URLs in addition to file paths as the input for the `describe`, `validate`, and `convert` commands.
```shell
# gpq describe https://github.com/opengeospatial/geoparquet/raw/v1.0.0/examples/example.parquet
╭────────────────────┬────────┬────────────┬────────────┬─────────────┬──────────┬───────────────────────┬───────────────────────────┬──────────────────────────╮
│ COLUMN             │ TYPE   │ ANNOTATION │ REPETITION │ COMPRESSION │ ENCODING │ GEOMETRY TYPES        │ BOUNDS                    │ DETAIL                   │
├────────────────────┼────────┼────────────┼────────────┼─────────────┼──────────┼───────────────────────┼───────────────────────────┼──────────────────────────┤
│ pop_est            │ double │            │ 0..1       │ snappy      │          │                       │                           │                          │
│ continent          │ binary │ string     │ 0..1       │ snappy      │          │                       │                           │                          │
│ name               │ binary │ string     │ 0..1       │ snappy      │          │                       │                           │                          │
│ iso_a3             │ binary │ string     │ 0..1       │ snappy      │          │                       │                           │                          │
│ gdp_md_est         │ int64  │            │ 0..1       │ snappy      │          │                       │                           │                          │
│ geometry           │ binary │            │ 0..1       │ snappy      │ WKB      │ Polygon, MultiPolygon │ [-180, -90, 180, 83.6451] │  edges │ planar          │
│                    │        │            │            │             │          │                       │                           │  crs   │ WGS 84 (CRS84)  │
├────────────────────┼────────┴────────────┴────────────┴─────────────┴──────────┴───────────────────────┴───────────────────────────┴──────────────────────────┤
│ Rows               │ 5                                                                                                                                        │
│ Row Groups         │ 1                                                                                                                                        │
│ GeoParquet Version │ 1.0.0                                                                                                                                    │
╰────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

You can also validate given an input URL (with or without the `--metadata-only` flag, with the flag skips scanning all geometries):
```shell
# gpq validate https://github.com/opengeospatial/geoparquet/raw/v1.0.0/examples/example.parquet --metadata-only
Summary: Passed 16 checks.

Metadata and schema checks only.  Skipped 4 data scanning checks.

 ✓ file must include a "geo" metadata key
 ✓ metadata must be a JSON object
 ✓ metadata must include a "version" string
 ✓ metadata must include a "primary_column" string
 ✓ metadata must include a "columns" object
 ✓ column metadata must include the "primary_column" name
 ✓ column metadata must include a valid "encoding" string
 ✓ column metadata must include a "geometry_types" list
 ✓ optional "crs" must be null or a PROJJSON object
 ✓ optional "orientation" must be a valid string
 ✓ optional "edges" must be a valid string
 ✓ optional "bbox" must be an array of 4 or 6 numbers
 ✓ optional "epoch" must be a number
 ✓ geometry columns must not be grouped
 ✓ geometry columns must be stored using the BYTE_ARRAY parquet type
 ✓ geometry columns must be required or optional, not repeated
```

And the same works for the `convert` command:
```shell
gpq convert https://github.com/opengeospatial/geoparquet/raw/v1.0.0/examples/example.parquet example.geojson
```

This doesn't yet add support for reading from blob storage.  I'll add that separately.

Fixes #93.