### PR TITLE
Increase timeout for golangci-lint-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.54.1
-          args: "--out-${NO_FUTURE}format colored-line-number"
+          args: "--timeout=5m --out-${NO_FUTURE}format colored-line-number"
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The right fix here is to figure out why the cache isn't working, but I'll save that for later.

Perhaps related https://github.com/golangci/golangci-lint-action/issues/863.