### PR TITLE
Use the pqarrow file writer

### DIFF
--- a/internal/geoparquet/geoparquet.go
+++ b/internal/geoparquet/geoparquet.go
@@ -12,6 +12,7 @@ import (
 	"github.com/apache/arrow/go/v14/parquet"
 	"github.com/apache/arrow/go/v14/parquet/compress"
 	"github.com/apache/arrow/go/v14/parquet/file"
+	"github.com/apache/arrow/go/v14/parquet/pqarrow"
 	"github.com/apache/arrow/go/v14/parquet/schema"
 	"github.com/paulmach/orb/encoding/wkb"
 	"github.com/paulmach/orb/encoding/wkt"
@@ -154,7 +155,7 @@ func FromParquet(input parquet.ReaderAtSeeker, output io.Writer, convertOptions 
 		return arrow.NewChunked(builder.Type(), transformed), nil
 	}
 
-	beforeClose := func(fileReader *file.Reader, fileWriter *file.Writer) error {
+	beforeClose := func(fileReader *file.Reader, fileWriter *pqarrow.FileWriter) error {
 		metadata := getMetadata(fileReader, convertOptions)
 		for name, geometryCol := range metadata.Columns {
 			if !datasetInfo.HasCollection(name) {

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/apache/arrow/go/v14/parquet"
 	"github.com/apache/arrow/go/v14/parquet/file"
+	"github.com/apache/arrow/go/v14/parquet/pqarrow"
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/encoding/wkb"
 	"github.com/planetlabs/gpq/internal/geojson"
@@ -87,7 +88,7 @@ func (s *Suite) copyWithMetadata(input parquet.ReaderAtSeeker, output io.Writer,
 	config := &pqutil.TransformConfig{
 		Reader: input,
 		Writer: output,
-		BeforeClose: func(fileReader *file.Reader, fileWriter *file.Writer) error {
+		BeforeClose: func(fileReader *file.Reader, fileWriter *pqarrow.FileWriter) error {
 			return fileWriter.AppendKeyValueMetadata(geoparquet.MetadataKey, metadata)
 		},
 	}


### PR DESCRIPTION
This updates the Parquet transform-by-column code to use the `pqarrow.FileWriter` instead of a `file.Writer`.  When using the `file.Writer`, I'm seeing some cases where invalid Parquet is generated (see https://github.com/apache/arrow/issues/38503).

Fixes #102.