### PR TITLE
Allow empty and null geometries in validation

### DIFF
--- a/internal/geo/geo.go
+++ b/internal/geo/geo.go
@@ -117,6 +117,9 @@ func DecodeGeometry(value any, encoding string) (*orbjson.Geometry, error) {
 		if !ok {
 			return nil, fmt.Errorf("expected bytes for wkb geometry, got %T", value)
 		}
+		if len(data) == 0 {
+			return nil, nil
+		}
 		g, err := wkb.Unmarshal(data)
 		if err != nil {
 			return nil, err

--- a/internal/validator/testdata/bad-crs-type/expected.json
+++ b/internal/validator/testdata/bad-crs-type/expected.json
@@ -48,58 +48,58 @@
     },
     {
       "title": "optional \"orientation\" must be a valid string",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "optional \"edges\" must be a valid string",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "optional \"bbox\" must be an array of 4 or 6 numbers",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "optional \"epoch\" must be a number",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "geometry columns must not be grouped",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "geometry columns must be stored using the BYTE_ARRAY parquet type",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "geometry columns must be required or optional, not repeated",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "all geometry values match the \"encoding\" metadata",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "all geometry types must be included in the \"geometry_types\" metadata (if not empty)",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "all polygon geometries must follow the \"orientation\" metadata (if present)",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     },
     {
       "title": "all geometries must fall within the \"bbox\" metadata (if present)",
-      "passed": false,
-      "run": false
+      "run": false,
+      "passed": false
     }
   ],
   "metadataOnly": false

--- a/internal/validator/testdata/with-empty-geometry/expected.json
+++ b/internal/validator/testdata/with-empty-geometry/expected.json
@@ -27,8 +27,8 @@
     },
     {
       "title": "column metadata must include the \"primary_column\" name",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "column metadata must include a valid \"encoding\" string",
@@ -58,48 +58,47 @@
     {
       "title": "optional \"bbox\" must be an array of 4 or 6 numbers",
       "run": true,
-      "passed": false,
-      "message": "expected \"bbox\" for column \"geometry\" to be a list, got a string: \"bogus\""
+      "passed": true
     },
     {
       "title": "optional \"epoch\" must be a number",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "geometry columns must not be grouped",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "geometry columns must be stored using the BYTE_ARRAY parquet type",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "geometry columns must be required or optional, not repeated",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all geometry values match the \"encoding\" metadata",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all geometry types must be included in the \"geometry_types\" metadata (if not empty)",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all polygon geometries must follow the \"orientation\" metadata (if present)",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all geometries must fall within the \"bbox\" metadata (if present)",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     }
   ],
   "metadataOnly": false

--- a/internal/validator/testdata/with-empty-geometry/input.json
+++ b/internal/validator/testdata/with-empty-geometry/input.json
@@ -1,0 +1,37 @@
+{
+  "metadata": {
+    "version": "1.0.0",
+    "primary_column": "geometry",
+    "columns": {
+      "geometry": {
+        "encoding": "WKB",
+        "geometry_types": ["Point"]
+      }
+    }
+  },
+  "data": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "with geometry"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [0, 0]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "empty geometry"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": []
+        }
+      }
+    ]
+  }
+}

--- a/internal/validator/testdata/with-null-geometry/expected.json
+++ b/internal/validator/testdata/with-null-geometry/expected.json
@@ -27,8 +27,8 @@
     },
     {
       "title": "column metadata must include the \"primary_column\" name",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "column metadata must include a valid \"encoding\" string",
@@ -58,48 +58,47 @@
     {
       "title": "optional \"bbox\" must be an array of 4 or 6 numbers",
       "run": true,
-      "passed": false,
-      "message": "expected \"bbox\" for column \"geometry\" to be a list, got a string: \"bogus\""
+      "passed": true
     },
     {
       "title": "optional \"epoch\" must be a number",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "geometry columns must not be grouped",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "geometry columns must be stored using the BYTE_ARRAY parquet type",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "geometry columns must be required or optional, not repeated",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all geometry values match the \"encoding\" metadata",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all geometry types must be included in the \"geometry_types\" metadata (if not empty)",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all polygon geometries must follow the \"orientation\" metadata (if present)",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     },
     {
       "title": "all geometries must fall within the \"bbox\" metadata (if present)",
-      "run": false,
-      "passed": false
+      "run": true,
+      "passed": true
     }
   ],
   "metadataOnly": false

--- a/internal/validator/testdata/with-null-geometry/input.json
+++ b/internal/validator/testdata/with-null-geometry/input.json
@@ -1,0 +1,34 @@
+{
+  "metadata": {
+    "version": "1.0.0",
+    "primary_column": "geometry",
+    "columns": {
+      "geometry": {
+        "encoding": "WKB",
+        "geometry_types": ["Point"]
+      }
+    }
+  },
+  "data": {
+    "type": "FeatureCollection",
+    "features": [
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "with geometry"
+        },
+        "geometry": {
+          "type": "Point",
+          "coordinates": [0, 0]
+        }
+      },
+      {
+        "type": "Feature",
+        "properties": {
+          "name": "without geometry"
+        },
+        "geometry": null
+      }
+    ]
+  }
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -237,6 +237,9 @@ func (v *Validator) Report(ctx context.Context, file *file.Reader) (*Report, err
 				if err != nil {
 					return nil, fmt.Errorf("failed to decode geometry for %q: %w", field.Name, err)
 				}
+				if geometry == nil {
+					continue
+				}
 				for i, rule := range decodedGeometryRules {
 					check := decodedGeometryChecks[i]
 					if err := rule.Value(field.Name, geometry.Geometry()); errors.Is(err, ErrFatal) {


### PR DESCRIPTION
Currently, if you run `gpq validate` against a Parquet file that has nulls for WKB encoded geometries, the program panics (see #188).  This addresses that.